### PR TITLE
feat: Dropout layer

### DIFF
--- a/nitorch/nn/modules/__init__.py
+++ b/nitorch/nn/modules/__init__.py
@@ -4,6 +4,7 @@ from . import base
 from . import cnn
 from . import conv
 from . import norm
+from . import dropout
 from . import pool
 from . import registration
 from . import spatial
@@ -14,6 +15,7 @@ from .base import *
 from .cnn import *
 from .conv import *
 from .norm import *
+from .dropout import *
 from .pool import *
 from .registration import *
 from .spatial import *

--- a/nitorch/nn/modules/cnn.py
+++ b/nitorch/nn/modules/cnn.py
@@ -1229,7 +1229,7 @@ class CNN(tnn.Sequential):
             reduction='max',
             activation='relu',
             batch_norm=False,
-            dropout=0.5):
+            dropout=1.0):
         """
 
         Parameters
@@ -1279,9 +1279,9 @@ class CNN(tnn.Sequential):
         batch_norm : bool or type or callable, default=False
             Batch normalization before each convolution.
 
-        dropout : float, default=0.5
+        dropout : sequence[float], default=1.0
             Dropout amount applied to the output of each fully connected layer (before activation).
-            Set to 0.0 to use no dropout.
+            Set to 0.0 or 1.0 to use no dropout.
 
         """
         self.dim = dim

--- a/nitorch/nn/modules/cnn.py
+++ b/nitorch/nn/modules/cnn.py
@@ -309,8 +309,8 @@ class StackedConv(tnn.ModuleList):
     By default, padding is used so that convolutions with stride 1
     preserve spatial dimensions.
 
-    (BatchNorm? > [Grouped]Conv > Activation? > Stitch?)* > 
-    (BatchNorm? > [Grouped](StridedConv|Conv > Pool) > Activation? > Stitch?)
+    (BatchNorm? > [Grouped]Conv > Dropout?(Activation)? > Stitch?)* > 
+    (BatchNorm? > [Grouped](StridedConv|Conv > Pool) > Dropout?(Activation)? > Stitch?)
     """
     
     def __init__(
@@ -329,7 +329,8 @@ class StackedConv(tnn.ModuleList):
             output_padding=0,
             bias=True,
             residual=False,
-            return_last=False):
+            return_last=False,
+            dropout=0.0):
         """
 
         Parameters
@@ -353,7 +354,7 @@ class StackedConv(tnn.ModuleList):
         batch_norm : [sequence of] bool, default=False
             Batch normalization before each convolution.
             
-        stride : int or sequence[int], default=2
+        stride : int or sequence[int], default=1
             Up to one value per spatial dimension.
             `output_shape \approx input_shape // stride`
             
@@ -397,6 +398,9 @@ class StackedConv(tnn.ModuleList):
             whereas 'cat' returns all concatenated input arguments.
             `True` is equivalent to 'single'.
 
+        dropout : float or type or callable, default=0.0
+            Apply dropout (if 0.0<p<=1.0)
+
         """
         self.dim = dim
         self.residual = residual
@@ -412,6 +416,7 @@ class StackedConv(tnn.ModuleList):
         groups = [g or s for g, s in zip(groups, stitch)]
         activation = expand_list(make_list(activation), nb_layers, default='relu')
         batch_norm = expand_list(make_list(batch_norm), nb_layers, default=False)
+        dropout = expand_list(make_list(dropout), nb_layers, default=False)
         bias = expand_list(make_list(bias), nb_layers, default=True)
         
         if pool not in (None, 'up', 'conv') and transposed:
@@ -422,6 +427,7 @@ class StackedConv(tnn.ModuleList):
             out_channels, 
             activation,
             batch_norm,
+            dropout,
             groups, 
             stitch,
             bias)
@@ -429,11 +435,12 @@ class StackedConv(tnn.ModuleList):
         
         # stacked conv (without strides)
         modules = []
-        for d, (i, o, a, bn, g, s, b) in enumerate(all_shapes):
+        for d, (i, o, a, bn, do, g, s, b) in enumerate(all_shapes):
             modules.append(Conv(
                 dim, i, o, kernel_size,
                 activation=a,
                 batch_norm=bn,
+                dropout=do,
                 padding='auto',
                 groups=g,
                 bias=b))
@@ -441,12 +448,13 @@ class StackedConv(tnn.ModuleList):
                 modules.append(Stitch(s, s))
         
         # last conv (strided if not pool)
-        i, o, a, bn, g, s, b = final_shape
+        i, o, a, bn, do, g, s, b = final_shape
         modules.append(Conv(
             dim, i, o, kernel_size,
             transposed=transposed and not pool,
             activation=a,
             batch_norm=bn,
+            dropout=do,
             stride=1 if pool else stride,
             padding='auto',
             groups=g,
@@ -466,6 +474,7 @@ class StackedConv(tnn.ModuleList):
                     transposed=transposed,
                     activation=None,
                     batch_norm=bn,
+                    dropout=do,
                     stride=stride,
                     padding='auto',
                     groups=g,
@@ -1219,7 +1228,8 @@ class CNN(tnn.Sequential):
             pool=None,
             reduction='max',
             activation='relu',
-            batch_norm=False):
+            batch_norm=False,
+            dropout=0.5):
         """
 
         Parameters
@@ -1268,6 +1278,11 @@ class CNN(tnn.Sequential):
 
         batch_norm : bool or type or callable, default=False
             Batch normalization before each convolution.
+
+        dropout : float, default=0.5
+            Dropout amount applied to the output of each fully connected layer (before activation).
+            Set to 0.0 to use no dropout.
+
         """
         self.dim = dim
 
@@ -1305,7 +1320,8 @@ class CNN(tnn.Sequential):
                           in_channels=last_encoder,
                           out_channels=stack,
                           kernel_size=1,
-                          activation=activation_stack)
+                          activation=activation_stack,
+                          dropout=dropout)
         modules.append(('stack', stk))
 
         super().__init__(OrderedDict(modules))

--- a/nitorch/nn/modules/conv.py
+++ b/nitorch/nn/modules/conv.py
@@ -832,16 +832,16 @@ class Conv(Module):
 
         # Add dropout
         p = dropout  # dropout amount
-        if isinstance(p, float) and p > 0.0 and p <= 1.0:
+        if isinstance(p, float) and p > 0.0 and p < 1.0:
             dropout = Dropout(p=p)
-        self.dropout = (dropout(p=p) 
-                           if inspect.isclass(dropout)
-                           else dropout if callable(dropout)
-                           else None)
-        if self.dropout is not None:
+        dropout = (dropout(p=p) 
+                    if inspect.isclass(dropout)
+                    else dropout if callable(dropout)
+                    else None)
+        if dropout is not None:
             # integrate dropout into activation function
-            self.dropout.activation = self.activation
-            self.activation = self.dropout
+            dropout.activation = self.activation
+            self.activation = dropout
 
     @property
     def weight(self):

--- a/nitorch/nn/modules/conv.py
+++ b/nitorch/nn/modules/conv.py
@@ -10,6 +10,7 @@ from nitorch.core.py import make_tuple
 from nitorch.core import py, utils
 from .base import nitorchmodule, Module
 from .norm import BatchNorm
+from .dropout import Dropout
 from ..activations import _map_activations
 
 # NOTE:
@@ -687,6 +688,7 @@ class Conv(Module):
                  output_padding=0,
                  activation=None,
                  batch_norm=False,
+                 dropout=0.0,
                  inplace=True):
         """
         Parameters
@@ -751,6 +753,12 @@ class Conv(Module):
             or a callable (an already instantiated class or a more simple
             function).
             
+        dropout : float or type or callable, optional
+            Dropout layer.
+            Can be a class (typically a Module), which is then instantiated,
+            or a callable (an already instantiated class or a more simple
+            function).
+
         inplace : bool, default=True
             Apply activation inplace if possible
             (i.e., not ``is_leaf and requires_grad``).
@@ -758,7 +766,7 @@ class Conv(Module):
         """
         super().__init__()
 
-        # Store dimension
+        # store in-place
         self.inplace = inplace
 
         # Check if "manual" grouped conv are required
@@ -813,14 +821,27 @@ class Conv(Module):
             activation = _map_activations.get(activation.lower(), None)
         self.activation = (activation() if inspect.isclass(activation)
                            else activation if callable(activation)
-                           else None)
-        
+                           else None)        
+
         if isinstance(activation, tnn.ReLU):
             self.conv.reset_parameters(a=0)
         elif isinstance(activation, tnn.LeakyReLU):
             self.conv.reset_parameters(a=activation.negative_slope)
         else:
             self.conv.reset_parameters()
+
+        # Add dropout
+        p = dropout  # dropout amount
+        if isinstance(p, float) and p > 0.0 and p <= 1.0:
+            dropout = Dropout(p=p)
+        self.dropout = (dropout(p=p) 
+                           if inspect.isclass(dropout)
+                           else dropout if callable(dropout)
+                           else None)
+        if self.dropout is not None:
+            # integrate dropout into activation function
+            self.dropout.activation = self.activation
+            self.activation = self.dropout
 
     @property
     def weight(self):
@@ -939,7 +960,7 @@ class Conv(Module):
                 not (x.is_leaf and x.requires_grad)):
             activation.inplace = True
 
-        # BatchNorm + Convolution + Activation
+        # BatchNorm + Convolution + Activation (Dropout before | Dropout after)
         if batch_norm:
             x = batch_norm(x)
         x = self.conv(x, **overload)

--- a/nitorch/nn/modules/dropout.py
+++ b/nitorch/nn/modules/dropout.py
@@ -61,12 +61,10 @@ class Dropout(Module):
             return self.activation(x)
 
     def __str__(self):
-        s = ['']
-        if self.dropout.p != 0.5:
-            s += [f'p={p}']
-        if not self.before_activation:
-            s += [f'before_activation=False']
-        s = ', '.join(s)
-        return f'Dropout({s})'
+        if self.before_activation:
+            s = f"{self.activation} o Dropout(p={self.dropout.p})"
+        else:
+            s = f"Dropout(p={self.dropout.p}) o {self.activation}"
+        return s
 
     __repr__ = __str__

--- a/nitorch/nn/modules/dropout.py
+++ b/nitorch/nn/modules/dropout.py
@@ -1,0 +1,72 @@
+"""Dropout layer"""
+from torch import nn as tnn
+from .base import Module, nitorchmodule
+
+
+class Dropout(Module):
+    """Dropout layer (only applied during training).
+    
+    Dropout is commonly applied both before, and after, the activation function:
+
+    https://stats.stackexchange.com/a/317313
+
+    This class is written as to enable this usage. This is achieved by simply pointing the class to
+    the activation function and specifying if Dropout should be applied before or after calling it.
+
+    """
+    def __init__(self, activation=None, before_activation=True, **kwargs):
+        """
+        Parameters
+        ----------
+        activation : callable, optional
+            activation function
+        before_activation : bool, default=True
+            apply dropout before, or after, activation
+        p : float, default=0.5
+            Probability of an element to be zeroed.
+        inplace  : default=False
+            If set to True, will do this operation in-place.
+
+        """
+        super().__init__()
+
+        # activation        
+        if activation is None:
+            activation = lambda x: activation(x)
+        self.activation = activation
+        self.before_activation = before_activation
+
+        # Add Layer
+        self.dropout = nitorchmodule(tnn.Dropout)(**kwargs)
+
+    def forward(self, x):
+        """Forward pass.
+
+        Parameters
+        ----------
+        x : (batch, channel, *spatial) tensor
+            Input tensor
+
+        Returns
+        -------
+        x : (batch, channel, *spatial) tensor
+            Output tensor with dropout applied
+
+        """
+        if self.training:
+            return self.activation(self.dropout(x)) \
+                if self.before_activation \
+                else self.dropout(self.activation(x))
+        else:
+            return self.activation(x)
+
+    def __str__(self):
+        s = ['']
+        if self.dropout.p != 0.5:
+            s += [f'p={p}']
+        if not self.before_activation:
+            s += [f'before_activation=False']
+        s = ', '.join(s)
+        return f'Dropout({s})'
+
+    __repr__ = __str__


### PR DESCRIPTION
@balbasty could you  please tell me if you think this integration of Dropout into nitorch is okay?

I have added a dropout module, that is integrated into the conv class (see Line 833 in conv.py and Line 7 in dropout.py). I have a flag in the forward call of Dropout to ensure it is only applied during training. The only thing that is a bit messed up is the model printing:

![image](https://user-images.githubusercontent.com/6413806/129744039-fe70c2cc-dcc3-465c-891b-5f3c4a160569.png)

because how I merge Dropout and the activation function.

The only model where I have included the dropout option is the regular CNN.