### PR TITLE
Use double data type for the SPM atlas affine

### DIFF
--- a/nitorch/tools/uniseg/_api.py
+++ b/nitorch/tools/uniseg/_api.py
@@ -237,7 +237,7 @@ def get_spm_prior(**backend):
     f = io.map(fname).movedim(-1, 0)[:-1]  # drop background
     aff = f.affine
     dat = f.fdata(**backend)
-    aff = aff.to(**utils.backend(dat))
+    aff = aff.to(**utils.backend(dat)).type(torch.float64)
     return dat, aff
 
 

--- a/nitorch/tools/uniseg/_api.py
+++ b/nitorch/tools/uniseg/_api.py
@@ -237,7 +237,7 @@ def get_spm_prior(**backend):
     f = io.map(fname).movedim(-1, 0)[:-1]  # drop background
     aff = f.affine
     dat = f.fdata(**backend)
-    aff = aff.to(**utils.backend(dat)).type(torch.float64)
+    aff = aff.to(**utils.backend(dat))
     return dat, aff
 
 

--- a/nitorch/tools/uniseg/_fit.py
+++ b/nitorch/tools/uniseg/_fit.py
@@ -308,6 +308,7 @@ class SpatialMixture:
         # default affine
         if aff is None:
             aff = spatial.affine_default(X.shape[1:])
+        aff = aff.to(X.dtype)
 
         # Subsample
         X0, W0, aff0 = X, W, aff


### PR DESCRIPTION
@balbasty, UniSeg errored for me because the input affine I gave was torch32. think it is best to use double data type for the SPM atlas affine matrix because it is what is returned by default when reading with io.map().affine, plus it is better for numerical precision without much memory overhead.