### PR TITLE
add initial Dockerfile

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -20,9 +20,7 @@ RUN conda install --yes --quiet --freeze-installed --channel conda-forge \
         python-wget \
         scipy \
     # Clean up the caches so they are not part of the final image.
-    && conda clean --all --yes \
-    # Run first-time setup for matplotlib.
-    && python -c 'import matplotlib'
+    && conda clean --all --yes
 
 # In this stage, set up the final image.
 FROM python-deps

--- a/Dockerfile
+++ b/Dockerfile
@@ -13,7 +13,7 @@ RUN NI_COMPILED_BACKEND="C" \
 
 # In this stage, install python dependencies that are not in install_requires.
 FROM pytorch/pytorch:${PYTORCH_TAG_PREFIX}-runtime as python-deps
-RUN conda install --yes --quiet --freeze-installed \
+RUN conda install --yes --quiet --freeze-installed --channel conda-forge \
         appdirs \
         matplotlib \
         nibabel \

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,0 +1,14 @@
+# Set the pytorch version. We set this once here so that both stages use the same
+# pytorch version (with the same cuda and cudnn versions). This includes the image
+# tag without '-devel' or '-runtime'. Stage 1 uses devel and stage 2 uses runtime.
+ARG PYTORCH_TAG_PREFIX="1.12.1-cuda11.3-cudnn8"
+
+FROM pytorch/pytorch:$PYTORCH_TAG_PREFIX-devel as builder
+WORKDIR /opt/nitorch
+COPY . .
+RUN NI_COMPILED_BACKEND="C" python setup.py bdist_wheel
+
+# Stage 2: Install pre-compiled package.
+FROM pytorch/pytorch:$PYTORCH_TAG_PREFIX-runtime
+COPY --from=builder /opt/nitorch/dist/ /opt/nitorch-wheel/
+RUN python -m pip install --no-cache-dir /opt/nitorch-wheel/*

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,16 +1,30 @@
-# Set the pytorch version. We set this once here so that both stages use the same
+# Set the pytorch version. We set this once here so that all stages use the same
 # pytorch version (with the same cuda and cudnn versions). This includes the image
-# tag without '-devel' or '-runtime'. Stage 1 uses devel and stage 2 uses runtime.
+# tag without '-devel' or '-runtime'. The first stage uses devel and others use runtime.
 ARG PYTORCH_TAG_PREFIX="1.12.1-cuda11.3-cudnn8"
 
-FROM pytorch/pytorch:$PYTORCH_TAG_PREFIX-devel as builder
+# In this stage, build a nitorch wheel.
+FROM pytorch/pytorch:${PYTORCH_TAG_PREFIX}-devel as builder
 WORKDIR /opt/nitorch
 COPY . .
 RUN NI_COMPILED_BACKEND="C" \
     TORCH_CUDA_ARCH_LIST="3.5 5.2 6.0 6.1 7.0+PTX 8.0" \
     python setup.py bdist_wheel
 
-# Stage 2: Install pre-compiled package.
-FROM pytorch/pytorch:$PYTORCH_TAG_PREFIX-runtime
+# In this stage, install python dependencies that are not in install_requires.
+FROM pytorch/pytorch:${PYTORCH_TAG_PREFIX}-runtime as python-deps
+RUN conda install --yes --quiet --freeze-installed \
+        appdirs \
+        matplotlib \
+        nibabel \
+        python-wget \
+        scipy \
+    # Clean up the caches so they are not part of the final image.
+    && conda clean --all --yes \
+    # Run first-time setup for matplotlib.
+    && python -c 'import matplotlib'
+
+# In this stage, set up the final image.
+FROM python-deps
 COPY --from=builder /opt/nitorch/dist/ /opt/nitorch-wheel/
 RUN python -m pip install --no-cache-dir /opt/nitorch-wheel/*

--- a/Dockerfile
+++ b/Dockerfile
@@ -6,7 +6,9 @@ ARG PYTORCH_TAG_PREFIX="1.12.1-cuda11.3-cudnn8"
 FROM pytorch/pytorch:$PYTORCH_TAG_PREFIX-devel as builder
 WORKDIR /opt/nitorch
 COPY . .
-RUN NI_COMPILED_BACKEND="C" python setup.py bdist_wheel
+RUN NI_COMPILED_BACKEND="C" \
+    TORCH_CUDA_ARCH_LIST="3.5 5.2 6.0 6.1 7.0+PTX 8.0" \
+    python setup.py bdist_wheel
 
 # Stage 2: Install pre-compiled package.
 FROM pytorch/pytorch:$PYTORCH_TAG_PREFIX-runtime

--- a/setup_cext.py
+++ b/setup_cext.py
@@ -54,7 +54,7 @@ def torch_version(astuple=True):
 
 
 def torch_cuda_version(astuple=True):
-    if not torch.cuda.is_available():
+    if torch.version.cuda is None:
         return None
     version = torch.version.cuda.split('.')
     version = tuple(int(v) for v in version)
@@ -66,7 +66,7 @@ def torch_cuda_version(astuple=True):
 
 
 def torch_cudnn_version(astuple=True):
-    if not torch.cuda.is_available():
+    if torch.version.cuda is None:
         return None
     version = torch.backends.cudnn.version()
     version = (version//1000, version//100 % 10, version % 100)
@@ -175,7 +175,7 @@ def torch_include_dirs(use_cuda=False, use_cudnn=False):
 
 
 def cuda_check():
-    if not torch.cuda.is_available():
+    if torch.version.cuda is None:
         print('PyTorch was not compiled with CUDA. Compiling for CPU only.')
         return False
     local_version = cuda_version()


### PR DESCRIPTION
This dockerfile builds nitorch and compiles the extensions. The first
stage builds the (compiled) wheel. The second build stage installs that
wheel. The dockerfile bootstraps pytorch's official docker image. The
first stage uses their "devel" image and the second image uses
"runtime".

We should test that nitorch is usable and actually uses the compiled
things. It is possible we will need to update the `LD_LIBRARY_PATH` in
the second build stage.