### PR TITLE
Set nibabel version

### DIFF
--- a/conda/nitorch-demo.yml
+++ b/conda/nitorch-demo.yml
@@ -7,7 +7,7 @@ dependencies:
   - pytorch=1.5
   - cudatoolkit=10.1
   - numpy
-  - nibabel
+  - nibabel=4.0.2
   - matplotlib
   - pip
   - scipy

--- a/conda/nitorch-demo.yml
+++ b/conda/nitorch-demo.yml
@@ -7,7 +7,7 @@ dependencies:
   - pytorch=1.5
   - cudatoolkit=10.1
   - numpy
-  - nibabel=4.0.2
+  - nibabel<=4
   - matplotlib
   - pip
   - scipy

--- a/conda/nitorch.yml
+++ b/conda/nitorch.yml
@@ -7,7 +7,7 @@ dependencies:
   - pytorch=1.5
   - cudatoolkit=10.1
   - numpy
-  - nibabel=4.0.2
+  - nibabel<=4
   - pip
   - matplotlib
   - scipy

--- a/conda/nitorch.yml
+++ b/conda/nitorch.yml
@@ -7,7 +7,7 @@ dependencies:
   - pytorch=1.5
   - cudatoolkit=10.1
   - numpy
-  - nibabel
+  - nibabel=4.0.2
   - pip
   - matplotlib
   - scipy

--- a/setup.cfg
+++ b/setup.cfg
@@ -32,14 +32,14 @@ console_scripts =
 [options.extras_require]
 all =
     numpy
-    nibabel==4.0.2
+    nibabel<=4
     tiffile
     wget
     appdirs
     matplotlib
 io =
     numpy
-    nibabel==4.0.2
+    nibabel<=4
     tifffile
 data =
     wget
@@ -50,7 +50,7 @@ numpy =
     numpy
 nibabel =
     numpy
-    nibabel==4.0.2
+    nibabel<=4
 tiff =
     numpy
     tifffile

--- a/setup.cfg
+++ b/setup.cfg
@@ -32,14 +32,14 @@ console_scripts =
 [options.extras_require]
 all =
     numpy
-    nibabel
+    nibabel==4.0.2
     tiffile
     wget
     appdirs
     matplotlib
 io =
     numpy
-    nibabel
+    nibabel==4.0.2
     tifffile
 data =
     wget
@@ -50,7 +50,7 @@ numpy =
     numpy
 nibabel =
     numpy
-    nibabel
+    nibabel==4.0.2
 tiff =
     numpy
     tifffile


### PR DESCRIPTION
It seems as `nitorch.io` errors when using the latest version of nibabel as its backend:
```py
AttributeError: type object 'ArrayProxy' has no attribute 'order'
```
Setting the nibabel version that nitorch uses to an older one seems to fix the problem.

@balbasty, have I changed the nibabel version in all places needed?