### PR TITLE
Fix to vexp CLI

### DIFF
--- a/nitorch/cli/registration/vexp/main.py
+++ b/nitorch/cli/registration/vexp/main.py
@@ -65,8 +65,9 @@ def vexp(inp, type='displacement', unit='voxel', inverse=False,
     aff = aff.to(device=device)
 
     # exponentiate
+    displacement = True if (type.lower()[0] == 'd') else False
     dat = spatial.exp(dat[None], inverse=inverse, steps=steps, bound=bound,
-                      inplace=True, displacement=(type.lower()[0] == 'd'))[0]
+                      displacement=displacement)[0]
     if unit == 'mm':
         # if type.lower()[0] == 'd':
         #     vx = spatial.voxel_size(aff)


### PR DESCRIPTION
* inplace argument removed as no longer in spatial.exp
* displacement option should be given as bool, not char

with these fixes, converting a velocity field to a displacement field works well for me.